### PR TITLE
#42 commandline option for rule file format is updated.

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
@@ -72,7 +72,7 @@ public abstract class HeadlessCryptoScanner {
 
 		if (options.hasOption("rulesDir")) {
 			String resourcesPath = options.getOptionValue("rulesDir");
-			if(options.hasOption("ruleFormat") && options.getOptionValue("ruleFormat").equals("cryptslbin")) {
+			if(options.hasOption("rulesInBin")) {
 				rules = CrySLRulesetSelector.makeFromPath(new File(resourcesPath), "cryptslbin");
 			}else {
 				rules = CrySLRulesetSelector.makeFromPath(new File(resourcesPath),"cryptsl");
@@ -267,7 +267,7 @@ public abstract class HeadlessCryptoScanner {
 		if (rules != null) {
 			return rules;
 		}
-		if(options.hasOption("Ruleformat") && options.getOptionValue("ruleFormat").equals("cryptslbin")) {
+		if(options.hasOption("rulesInBin")) {
 			return rules = CrySLRulesetSelector.makeFromRuleset("src/main/resources/JavaCryptographicArchitecture", "cryptslbin",Ruleset.JavaCryptographicArchitecture);
 		}else {
 			return rules = CrySLRulesetSelector.makeFromRuleset("src/main/resources/JavaCryptographicArchitecture", "cryptsl", Ruleset.JavaCryptographicArchitecture);

--- a/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScannerOptions.java
+++ b/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScannerOptions.java
@@ -19,8 +19,8 @@ public class HeadlessCryptoScannerOptions extends Options {
 				.desc("Specify the directory for the CrySL rules").build();
 		addOption(rulesDir);
 		
-		Option ruleFormat = Option.builder().longOpt("ruleFormat").hasArg().desc("Specify the rule format for the CrySL rules").build();
-		addOption(ruleFormat);
+		Option rulesInBin = Option.builder().longOpt("rulesInBin").hasArg(false).desc("Specify the rule format for the CrySL rules").build();
+		addOption(rulesInBin);
 
 		Option rulesFormat = Option.builder().longOpt("rulesInSrc").hasArg(false).desc("Specfiy that rules passed as parameter are in source format.").build();
 		addOption(rulesFormat);


### PR DESCRIPTION
rulesInBin option is added to commandline options for reading rule files in cryptslbin format. 
(By default read rules in cryptsl format)